### PR TITLE
fix: remove text input default props warning

### DIFF
--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -176,9 +176,9 @@ const TextInputIcon = ({
 };
 TextInputIcon.displayName = "TextInput.Icon";
 
-TextInputIcon.defaultProps = {
-  forceTextInputFocus: true,
-};
+// TextInputIcon.defaultProps = {
+//   forceTextInputFocus: true,
+// };
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
fixing  ERROR  Warning: TextInput.Icon: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.

https://github.com/callstack/react-native-paper/issues/4382
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
